### PR TITLE
fix: direction issue when moving in gesture

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "pub": "rc-tools run pub --babel-runtime",
     "lint": "rc-tools run lint",
     "test": "jest",
-    "coverage": "jest --coverage && cat ./coverage/lcov.info | coveralls"
+    "coverage": "jest --coverage"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-gesture",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Support gesture for react component",
   "keywords": [
     "react",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -93,6 +93,7 @@ export interface IGestureStatus {
   /* now status snapshot */
   time: number;
   touches: Finger[];
+  preTouches: Finger[];
 
   mutliFingerStatus?: MultiFingerStatus[];
 
@@ -193,6 +194,11 @@ export default class Gesture extends Component<IGesture, any> {
   setGestureState = (params) => {
     if (!this.gesture) {
       this.gesture = {} as any;
+    }
+
+    // cache the previous touches
+    if (this.gesture.touches) {
+      this.gesture.preTouches = this.gesture.touches;
     }
     this.gesture = {
       ...this.gesture,
@@ -327,7 +333,7 @@ export default class Gesture extends Component<IGesture, any> {
     return shouldTriggerDirection(this.gesture.direction, this.directionSetting);
   }
   checkIfSingleTouchMove = () => {
-    const { pan, touches, moveStatus } = this.gesture;
+    const { pan, touches, moveStatus, preTouches } = this.gesture;
     if (touches.length > 1) {
       this.setGestureState({
         pan: false,
@@ -337,8 +343,7 @@ export default class Gesture extends Component<IGesture, any> {
       return;
     }
     if (moveStatus) {
-      const { x, y } = moveStatus;
-      const direction = getDirection(x, y);
+      const direction = getDirection(preTouches[0], touches[0]);
       this.setGestureState({
         direction,
       });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import {
   getEventName, now,
   calcMutliFingerStatus, calcMoveStatus,
   shouldTriggerSwipe, shouldTriggerDirection,
-  getDirection, getDirectionEventName,
+  getMovingDirection, getDirectionEventName,
 } from './util';
 import { PRESS, DIRECTION_ALL, DIRECTION_VERTICAL, DIRECTION_HORIZONTAL } from './config';
 
@@ -343,7 +343,7 @@ export default class Gesture extends Component<IGesture, any> {
       return;
     }
     if (moveStatus) {
-      const direction = getDirection(preTouches[0], touches[0]);
+      const direction = getMovingDirection(preTouches[0], touches[0]);
       this.setGestureState({
         direction,
       });

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -69,20 +69,23 @@ export function shouldTriggerDirection(direction, directionSetting) {
 
 /**
  * @private
- * get the direction between two points
- * @param {Number} x
- * @param {Number} y
+ * get the direction between tow points when touch moving
+ * @param {Object} point1 coordinate point, include x & y attributes
+ * @param {Object} point2 coordinate point, include x & y attributes
  * @return {Number} direction
  */
-export function getDirection(x, y) {
-  if (x === y) {
+export function getDirection(point1, point2) {
+  const {x: x1, y: y1} = point1;
+  const {x: x2, y: y2} = point2;
+  const deltaX = x2 - x1;
+  const deltaY = y2 - y1;
+  if (deltaX === 0 && deltaY === 0) {
     return DIRECTION_NONE;
   }
-
-  if (Math.abs(x) >= Math.abs(y)) {
-    return x < 0 ? DIRECTION_LEFT : DIRECTION_RIGHT;
+  if (Math.abs(deltaX) >= Math.abs(deltaY)) {
+    return deltaX < 0 ? DIRECTION_LEFT : DIRECTION_RIGHT;
   }
-  return y < 0 ? DIRECTION_UP : DIRECTION_DOWN;
+  return deltaY < 0 ? DIRECTION_UP : DIRECTION_DOWN;
 }
 
 export function getDirectionEventName(direction) {

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -69,12 +69,31 @@ export function shouldTriggerDirection(direction, directionSetting) {
 
 /**
  * @private
+ * get the direction between two points
+ * Note: will change next version
+ * @param {Number} x
+ * @param {Number} y
+ * @return {Number} direction
+ */
+export function getDirection(x, y) {
+  if (x === y) {
+    return DIRECTION_NONE;
+  }
+  if (Math.abs(x) >= Math.abs(y)) {
+    return x < 0 ? DIRECTION_LEFT : DIRECTION_RIGHT;
+  }
+  return y < 0 ? DIRECTION_UP : DIRECTION_DOWN;
+}
+
+/**
+ * @private
  * get the direction between tow points when touch moving
+ * Note: will change next version
  * @param {Object} point1 coordinate point, include x & y attributes
  * @param {Object} point2 coordinate point, include x & y attributes
  * @return {Number} direction
  */
-export function getDirection(point1, point2) {
+export function getMovingDirection(point1, point2) {
   const {x: x1, y: y1} = point1;
   const {x: x2, y: y2} = point2;
   const deltaX = x2 - x1;


### PR DESCRIPTION
If set `direction="horizontal"`, when touch moving from `vertical` to `horizontal`, then has a bug.
So, i compare current point with previous point to fix it.