### PR TITLE
fix and refine:

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,12 @@
 
+0.0.20 / 2018-06-04
+==================
+
+  * fix and refine:
+    1. Add the event as a gesture property, and can be exposed to consumer. E.g.: rc-swipeout need using event to prevent scroll when touch moving.
+    2. Fixed a bug: panMove event could be invoked by unavailable touches. Look at the image for intuitional understanding: https://gw.alipayobjects.com/zos/rmsportal/nJviUPgzjtrUGCKrvUCz.gif.
+  * change version to 0.0.20
+
 0.0.17 / 2018-05-24
 ==================
 

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -150,6 +150,7 @@ class Demo extends Component<any, any> {
             direction="horizontal"
             onPanMove={ (e, args) => { this.moveSwiper(e, args); } }
             onPanEnd={ () => { this.resetSwiper(); } }
+            onTouchMove={ (e) => { console.log('still run touch move'); } }
           >
             <div style={{height: 200, backgroundColor: 'red'}}>
               <div className="swiper" ref={ (e) => { this.refSwiper = e; } }>

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -86,14 +86,14 @@ class Demo extends Component<any, any> {
     this.rootNode.style.transform = transform;
   }
   moveSwiper(e) {
-    const {event, moveStatus} = e;
+    const {srcEvent, moveStatus} = e;
     const {x, y} = e.moveStatus;
 
     this.swiperNode = ReactDOM.findDOMNode(this.refSwiper);
     this.swiperNode.style.transform = [`translateX(${x}px)`];
 
     // preventDefault, avoid trigger scroll event when touch moving.
-    event.preventDefault();
+    srcEvent.preventDefault();
   }
 
   resetSwiper() {

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -21,6 +21,17 @@ const style = `
     height: 80%;
     background-color: black;
   }
+  .swiper-container{
+    margin: 20px 0;
+  }
+  .swiper{
+    display: flex;
+    align-items: center;
+    text-align: center;
+    background-color: #CCC;
+    width: 100%;
+    height: 100%;
+  }
 `;
 
 class Demo extends Component<any, any> {
@@ -34,16 +45,13 @@ class Demo extends Component<any, any> {
   constructor(props) {
     super(props);
   }
-
   log = (type: string, keys?: string[]) => (...args) => {
-    // console.log(type, ...args);
     window.requestAnimationFrame(() => {
       this.doLog(type, keys, ...args);
       this.doTransform(type, ...args);
     });
   }
   doLog = (type, keys, ...args) => {
-    console.log('args', args[0].moveStatus);
     const extInfo = keys ? keys.map(key => `${key} = ${args[0][key]}`).join(', ') : '';
     const logEl = this.refs.log as any;
     logEl.innerHTML += `<p>${type} ${extInfo}</p>`;
@@ -77,6 +85,21 @@ class Demo extends Component<any, any> {
     this.rootNode = ReactDOM.findDOMNode(this.root);
     this.rootNode.style.transform = transform;
   }
+  moveSwiper(e) {
+    const {event, moveStatus} = e;
+    const {x, y} = e.moveStatus;
+
+    this.swiperNode = ReactDOM.findDOMNode(this.refSwiper);
+    this.swiperNode.style.transform = [`translateX(${x}px)`];
+
+    // preventDefault, avoid trigger scroll event when touch moving.
+    event.preventDefault();
+  }
+
+  resetSwiper() {
+    this.swiperNode = ReactDOM.findDOMNode(this.refSwiper);
+    this.swiperNode.style.transform = [`translateX(0px)`];
+  }
 
   render() {
     return (
@@ -85,7 +108,7 @@ class Demo extends Component<any, any> {
         <div ref="log" style={{height: 100, overflow: 'auto', margin: 10}}/>
         <div className="outter">
           <Gesture
-            direction="horizontal"
+            direction="all"
             enablePinch
             enableRotate
             onTap={this.log('onTap')}
@@ -119,6 +142,19 @@ class Demo extends Component<any, any> {
             onPanDown={this.log('onPanDown', ['moveStatus', 'direction'])}
           >
             <div className="inner" ref={(el) => { this.root = el; }}>
+            </div>
+          </Gesture>
+        </div>
+        <div className="swiper-container">
+          <Gesture
+            direction="horizontal"
+            onPanMove={ (e, args) => { this.moveSwiper(e, args); } }
+            onPanEnd={ () => { this.resetSwiper(); } }
+          >
+            <div style={{height: 200, backgroundColor: 'red'}}>
+              <div className="swiper" ref={ (e) => { this.refSwiper = e; } }>
+              This is simple swiper demo. Only allow horizontal direction and height=200px to test scroll event.
+              </div>
             </div>
           </Gesture>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-gesture",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Support gesture for react component",
   "keywords": [
     "react",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -120,8 +120,8 @@ export interface IGestureStatus {
   rotate?: boolean;
   rotation?: number; // Rotation (in deg) that has been done when multi-touch. 0 on a single touch.
 
-  /* event */
-  event: any;
+  /* event, such as TouchEvent, MouseEvent, PointerEvent */
+  srcEvent: any;
 };
 
 const directionMap = {
@@ -259,7 +259,7 @@ export default class Gesture extends Component<IGesture, any> {
       time: startTime,
       touches: startTouches,
       mutliFingerStatus: startMutliFingerStatus,
-      event: this.event,
+      srcEvent: this.event,
     });
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -339,7 +339,7 @@ export default class Gesture extends Component<IGesture, any> {
     return shouldTriggerDirection(this.gesture.direction, this.directionSetting);
   }
   checkIfSingleTouchMove = () => {
-    const { pan, touches, moveStatus, preTouches, availablePan } = this.gesture;
+    const { pan, touches, moveStatus, preTouches, availablePan = true } = this.gesture;
     if (touches.length > 1) {
       this.setGestureState({
         pan: false,
@@ -350,7 +350,7 @@ export default class Gesture extends Component<IGesture, any> {
     }
 
     // add avilablePan condition to fix the case in scrolling, which will cause unavailable pan move.
-    if (moveStatus && availablePan !== false) {
+    if (moveStatus && availablePan) {
       const {x, y} = moveStatus;
       const direction = getMovingDirection(preTouches[0], touches[0]);
       this.setGestureState({direction});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -105,6 +105,8 @@ export interface IGestureStatus {
 
   /* whether is a pan */
   pan?: boolean;
+  /* whether is an available pan */
+  availablePan?: boolean;
 
   /* whether is a swipe*/
   swipe?: boolean;
@@ -117,6 +119,9 @@ export interface IGestureStatus {
   /* whether is in rotate process */
   rotate?: boolean;
   rotation?: number; // Rotation (in deg) that has been done when multi-touch. 0 on a single touch.
+
+  /* event */
+  event: any;
 };
 
 const directionMap = {
@@ -254,6 +259,7 @@ export default class Gesture extends Component<IGesture, any> {
       time: startTime,
       touches: startTouches,
       mutliFingerStatus: startMutliFingerStatus,
+      event: this.event,
     });
   }
 
@@ -333,7 +339,7 @@ export default class Gesture extends Component<IGesture, any> {
     return shouldTriggerDirection(this.gesture.direction, this.directionSetting);
   }
   checkIfSingleTouchMove = () => {
-    const { pan, touches, moveStatus, preTouches } = this.gesture;
+    const { pan, touches, moveStatus, preTouches, availablePan } = this.gesture;
     if (touches.length > 1) {
       this.setGestureState({
         pan: false,
@@ -343,19 +349,25 @@ export default class Gesture extends Component<IGesture, any> {
       return;
     }
 
-    if (moveStatus) {
+    // add avilablePan condition to fix the case in scrolling, which will cause unavailable pan move.
+    if (moveStatus && availablePan !== false) {
+      const {x, y} = moveStatus;
       const direction = getMovingDirection(preTouches[0], touches[0]);
-      this.setGestureState({
-        direction,
-      });
+      this.setGestureState({direction});
+
       const eventName = getDirectionEventName(direction);
       if (!this.allowGesture()) {
+        // if the first move is unavailable, then judge all of remaining touch movings are also invalid.
+        if (!pan) {
+          this.setGestureState({availablePan: false});
+        }
         return;
       }
       if (!pan) {
         this.triggerCombineEvent('onPan', 'start');
         this.setGestureState({
           pan: true,
+          availablePan: true,
         });
       } else {
         this.triggerCombineEvent('onPan', eventName);


### PR DESCRIPTION
1. Add the event as a gesture property, and can be exposed to consumer. E.g.: rc-swipeout need using event to prevent scroll when touch moving.
2. Fixed a bug: panMove event could be invoked by unavailable touches. Look at the image for intuitional understanding: https://gw.alipayobjects.com/zos/rmsportal/nJviUPgzjtrUGCKrvUCz.gif.